### PR TITLE
ModifyOctet-SeparationOfConcerns

### DIFF
--- a/router.py
+++ b/router.py
@@ -86,19 +86,7 @@ class Router:
       if k.endswith('wpa_psk'):
         self.nvram[k] = ''
 
-  def modifyThirdOctet(self, leaseSettingsFile, router_id):
+  def addLeasesFromFile(self,leaseSettingsFile):
     leaseList = readLeases(leaseSettingsFile)
-    for leaseObject in leaseList:
-      ip_addr = leaseObject.ip_address.split('.')
-      third_octet = int(ip_addr[2])
-      if third_octet >= 200:
-        third_octet = str(200 + router_id)
-      elif 100 <= third_octet < 199:
-        third_octet = str(100 + router_id)
-      else:
-        third_octet = str(router_id)
-      ip_addr[2] = third_octet
-
-      leaseObject.ip_address = ".".join(ip_addr)
     for lease in leaseList:
         self.addLease(lease)


### PR DESCRIPTION
New flow of the mnvram.py:

1. Previous functionality which donot involve static lease are same.
2. When adding static leases, following 3 tasks are necessary.
      - readLeases from file
      - Modify the 3rd Octet of added leases
      - addLeases into router object
      
3. As you pointed out, there can be an use case of  existing static leases already on the router.  The 3rd Octet of these existing static leases also need to updated as per router id.


Therefore the current program flow is:
1. read leases from file
2. add leases into router object.  The router object now contains all leases (old  and new )
3. now modify the 3rd octet of all leases present in router object.

A Sub-class is NOT used here